### PR TITLE
Add `media.ParseTime` method to wrap all the possible time formatting layouts

### DIFF
--- a/media/timestamp.go
+++ b/media/timestamp.go
@@ -3,6 +3,7 @@ package media
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"time"
 
 	"github.com/tidwall/gjson"
@@ -10,7 +11,23 @@ import (
 )
 
 // TIME_FORMAT is a time.Parse compatible string representing the manner in which Instagram datetime strings are encoded.
-const TIME_FORMAT string = "Jan 2, 2006, 3:04 PM"
+// I mean that's the idea anyway. IG seems to change to format they use between exports... Basically what that means is
+// you should the `ParseTime` function (in this package) to parse IG dates.
+const TIME_FORMAT string = "Jan 2, 2006 3:04 PM"
+
+// TIME_FORMAT_UPPER is a time.Parse compatible string representing the manner in which Instagram datetimes encoded with upper-case AM/PM times.
+const TIME_FORMAT_UPPER string = "Jan 2, 2006 3:04 PM"
+
+// TIME_FORMAT_UPPER_COMMA is a time.Parse compatible string representing the manner in which Instagram datetimes encoded with upper-case AM/PM times
+// with dates and times separated by a comma.
+const TIME_FORMAT_UPPER_COMMA string = "Jan 2, 2006, 3:04 PM"
+
+// TIME_FORMAT_LOWER is a time.Parse compatible string representing the manner in which Instagram datetimes encoded with lower-case AM/PM times.
+const TIME_FORMAT_LOWER string = "Jan 2, 2006 3:04 pm"
+
+// TIME_FORMAT_LOWER_COMMA is a time.Parse compatible string representing the manner in which Instagram datetimes encoded with lower-case AM/PM times
+// with dates and times separated by a comma.
+const TIME_FORMAT_LOWER_COMMA string = "Jan 2, 2006, 3:04 pm"
 
 // AppendTakenCallback is a user-defined callback function to be applied to `time.Time` instances in the
 // `AppendTakenAtTimestampWithCallback` method after an initial datetime string has been parsed but before
@@ -34,7 +51,7 @@ func AppendTakenAtTimestampWithCallback(ctx context.Context, body []byte, cb App
 
 	str_created := created_rsp.String()
 
-	t, err := time.Parse(TIME_FORMAT, str_created)
+	t, err := ParseTime(str_created)
 
 	if err != nil {
 		return nil, fmt.Errorf("Failed to parse taken value (%s), %w", str_created, err)
@@ -56,4 +73,36 @@ func AppendTakenAtTimestampWithCallback(ctx context.Context, body []byte, cb App
 	}
 
 	return body, nil
+}
+
+func ParseTime(str_time string) (time.Time, error) {
+
+	layouts := []string{
+		TIME_FORMAT_UPPER,
+		TIME_FORMAT_LOWER,
+		TIME_FORMAT_UPPER_COMMA,
+		TIME_FORMAT_LOWER_COMMA,
+	}
+
+	var t time.Time
+	var err error
+
+	for _, layout := range layouts {
+
+		t, err = time.Parse(layout, str_time)
+
+		if err != nil {
+			slog.Debug("Failed to parse time", "time", str_time, "layout", layout, "error", err)
+			continue
+		}
+
+		break
+	}
+
+	if err != nil {
+		t := new(time.Time)
+		return *t, err
+	}
+
+	return t, nil
 }

--- a/media/timestamp_test.go
+++ b/media/timestamp_test.go
@@ -1,0 +1,24 @@
+package media
+
+import (
+	"testing"
+)
+
+func TestParseTime(t *testing.T) {
+
+	str_times := []string{
+		"Mar 10, 2023, 1:25 PM",
+		"Mar 10, 2023, 1:25 am",
+		"Mar 10, 2023 1:25 PM",
+		"Mar 10, 2023 1:25 am",
+	}
+
+	for _, str_t := range str_times {
+
+		_, err := ParseTime(str_t)
+
+		if err != nil {
+			t.Fatalf("Failed to parse '%s', %v", str_t, err)
+		}
+	}
+}


### PR DESCRIPTION
* Add `media.ParseTime` method to wrap all the possible time formatting layouts
* Improved tests
